### PR TITLE
Add commit information to the output

### DIFF
--- a/services/etl/main.py
+++ b/services/etl/main.py
@@ -12,19 +12,36 @@ app = Flask(__name__)
 
 # Document API URL
 DOCUMENT_URL = 'https://api.github.com/repos/PEDSnet/Data_Models/contents/PEDSnet/V2/docs/Pedsnet_CDM_V2_OMOPV5_ETL_Conventions.md'  # noqa
+COMMITS_URL = 'https://api.github.com/repos/PEDSnet/Data_Models/commits'
+FILE_PATH = 'PEDSnet/V2/docs/Pedsnet_CDM_V2_OMOPV5_ETL_Conventions.md'  # noqa
 
 # Required mediatype for the Accept header to get the raw content.
 GITHUB_RAW_MEDIATYPE = 'application/vnd.github.v3.raw'
+GITHUB_DEFAULT_MEDIATYPE = 'application/vnd.github.v3'
 
 # Token for GitHub authorization. Set on startup.
 GITHUB_AUTH_TOKEN = None
 
+content_last_modified = None
+content_etag = None
 
-def parse_document():
+commit_last_modified = None
+commit_etag = None
+
+
+def parse_model():
+    global content_etag, content_last_modified
+
     headers = {
         'Accept': GITHUB_RAW_MEDIATYPE,
         'Authorization': 'token ' + GITHUB_AUTH_TOKEN,
     }
+
+    if content_last_modified:
+        headers['If-Modified-Since'] = content_last_modified
+
+    if content_etag:
+        headers['If-None-Match'] = content_etag
 
     resp = requests.get(DOCUMENT_URL,
                         headers=headers,
@@ -32,20 +49,65 @@ def parse_document():
 
     resp.raise_for_status()
 
+    content_last_modified = resp.headers['Last-Modified']
+    content_etag = resp.headers['ETag']
+
     # Wrap decoded bytes in file-like object.
     buff = io.StringIO(resp.text)
 
     return Document(buff).parse()
 
 
+def parse_commit():
+    global commit_etag, commit_last_modified
+
+    headers = {
+        'Accept': GITHUB_DEFAULT_MEDIATYPE,
+        'Authorization': 'token ' + GITHUB_AUTH_TOKEN,
+    }
+
+    if commit_last_modified:
+        headers['If-Modified-Since'] = commit_last_modified
+
+    if commit_etag:
+        headers['If-None-Match'] = commit_etag
+
+    resp = requests.get(COMMITS_URL,
+                        params={'path': FILE_PATH},
+                        headers=headers,
+                        timeout=5)
+
+    resp.raise_for_status()
+
+    commit_last_modified = resp.headers['Last-Modified']
+    commit_etag = resp.headers['ETag']
+
+    # Get the most recent commit.
+    commit = resp.json()[0]
+
+    return {
+        'sha': commit['sha'],
+        'date': commit['commit']['committer']['date']
+    }
+
+
 @app.route('/', methods=['GET'])
 def index():
     try:
-        output = parse_document()
+        model = parse_model()
     except HTTPError:
         return 503, ''
 
-    resp = Response(json.dumps(output))
+    try:
+        commit = parse_commit()
+    except HTTPError:
+        return 503, ''
+
+    resp = Response(json.dumps({
+        'commit': commit,
+        'model': model,
+    }))
+
     resp.headers['Content-Type'] = 'application/json'
 
     return resp


### PR DESCRIPTION
The commit info includes the SHA1 and date under the ‘commit’ key. The
model itself is now nested under a ‘model’ key to prevent collision of
information.

Signed-off-by: Byron Ruth b@devel.io
