### PR TITLE
Implement conflict resolution

### DIFF
--- a/cmd/dqa/README.md
+++ b/cmd/dqa/README.md
@@ -34,10 +34,10 @@ The `merge-issues` command reads issues from a separate CSV file produced some e
 
 Each row is added to existing secondary report unless the secondary report already contains an record for the same `table`, `field`, and `issue_code`. In this case a conflict warning is printed to the console for the user to handle manually.
 
-To run, use the `merge-issues` subcommand. The first argument is the secondary report directory. The remaining arguments are the files containing the issues to be merged.
+To run, use the `merge-issues` subcommand. A GitHub token must be supplied since it fetches conflict threshold data from files on GitHub. The first argument is the secondary report directory. The remaining arguments are the files containing the issues to be merged or a directory containing those files.
 
 ```
-$ pedsnet-dqa merge-issues ./ETLv9 care_site_issues.csv measurement_issues.csv
+$ pedsnet-dqa merge-issues --token=... ./ETLv9 care_site_issues.csv measurement_issues.csv
 ```
 
 ## Rank Issues

--- a/cmd/dqa/issues/cmd.go
+++ b/cmd/dqa/issues/cmd.go
@@ -28,10 +28,10 @@ var Cmd = &cobra.Command{
 	Long: ``,
 
 	Example: `Merge issues into a secondary report.
-  pedsnet-dqa merge-issues SecondaryReports/CHOP/ETLv5 person_issue.csv
+  pedsnet-dqa merge-issues --token=... SecondaryReports/CHOP/ETLv5 person_issue.csv
 
 Multiple log files can be applied:
-  pedsnet-dqa merge-issues SecondaryReports/CHOP/ETLv5 *.csv`,
+  pedsnet-dqa merge-issues --token=... SecondaryReports/CHOP/ETLv5 *.csv`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 2 {

--- a/cmd/dqa/issues/github.go
+++ b/cmd/dqa/issues/github.go
@@ -88,11 +88,13 @@ func GetCatalog(token string) (Catalog, error) {
 
 		// Only process codes that are relevant.
 		checkCode := checkCodeRe.FindStringSubmatch(*file.Name)[1]
-		if _, ok := checkIssuesCodes[checkCode]; !ok {
-			continue
-		}
 
-		targetCode := checkIssuesCodes[checkCode]
+		var targetCode string
+		if _, ok := checkIssuesCodes[checkCode]; ok {
+			targetCode = checkIssuesCodes[checkCode]
+		} else {
+			targetCode = checkCode
+		}
 
 		// Fetch to get contents.
 		file, _, _, err = client.Repositories.GetContents(owner, repo, *file.Path, nil)

--- a/cmd/dqa/issues/github.go
+++ b/cmd/dqa/issues/github.go
@@ -1,0 +1,145 @@
+package issues
+
+import (
+	"bytes"
+	"encoding/csv"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PEDSnet/dqa-tool/uni"
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+const (
+	owner = "PEDSnet"
+	repo  = "Data-Quality"
+
+	catalogDirPath           = "DQA_Catalog/"
+	conflictAssociationsPath = "SecondaryReports/ConflictResolution/conflict_associations.csv"
+)
+
+var checkCodeRe = regexp.MustCompile(`^([A-C][A-C]-\d{3})_`)
+
+type Threshold struct {
+	Lower int
+	Upper int
+}
+
+type Catalog map[string]map[[2]string]*Threshold
+
+// NewGitHubReport initializes a new report for posting to GitHub.
+func GetCatalog(token string) (Catalog, error) {
+	tk := &oauth2.Token{
+		AccessToken: token,
+	}
+	ts := oauth2.StaticTokenSource(tk)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+
+	client := github.NewClient(tc)
+
+	// Get conflict associations
+	fileContent, _, _, err := client.Repositories.GetContents(owner, repo, conflictAssociationsPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	content, err := fileContent.GetContent()
+	if err != nil {
+		return nil, err
+	}
+
+	buf := uni.New(bytes.NewBufferString(content))
+	cr := csv.NewReader(buf)
+	if _, err := cr.Read(); err != nil {
+		return nil, err
+	}
+
+	checkIssuesCodes := make(map[string]string)
+
+	for {
+		row, err := cr.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		checkIssuesCodes[row[1]] = row[0]
+	}
+
+	// Fetch thresholds from conflict check mappings.
+	_, dirContent, _, err := client.Repositories.GetContents(owner, repo, catalogDirPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	catalog := make(Catalog)
+
+	for _, file := range dirContent {
+		if *file.Type == "dir" {
+			continue
+		}
+
+		if !checkCodeRe.MatchString(*file.Name) {
+			continue
+		}
+
+		// Only process codes that are relevant.
+		checkCode := checkCodeRe.FindStringSubmatch(*file.Name)[1]
+		if _, ok := checkIssuesCodes[checkCode]; !ok {
+			continue
+		}
+
+		targetCode := checkIssuesCodes[checkCode]
+
+		// Fetch to get contents.
+		file, _, _, err = client.Repositories.GetContents(owner, repo, *file.Path, nil)
+		if err != nil {
+			return nil, err
+		}
+		content, err := file.GetContent()
+		if err != nil {
+			return nil, err
+		}
+
+		buf := uni.New(bytes.NewBufferString(content))
+		cr := csv.NewReader(buf)
+		if _, err := cr.Read(); err != nil {
+			continue
+		}
+
+		if _, ok := catalog[targetCode]; !ok {
+			catalog[targetCode] = make(map[[2]string]*Threshold)
+		}
+
+		for {
+			row, err := cr.Read()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return nil, err
+			}
+
+			lower, err := strconv.Atoi(row[3])
+			if err != nil {
+				lower = 0
+			}
+			upper, err := strconv.Atoi(row[4])
+			if err != nil {
+				upper = 0
+			}
+
+			table := strings.ToLower(row[1])
+			field := strings.ToLower(row[2])
+
+			catalog[targetCode][[2]string{table, field}] = &Threshold{
+				Lower: lower,
+				Upper: upper,
+			}
+		}
+	}
+
+	return catalog, nil
+}

--- a/cmd/dqa/migrate/cmd.go
+++ b/cmd/dqa/migrate/cmd.go
@@ -152,7 +152,7 @@ func migrateCodes(path string) error {
 	descpos := -1
 
 	for i, col := range head {
-		switch strings.ToLower(col) {
+		switch strings.Replace(strings.ToLower(col), " ", "_", -1) {
 		case "check_code", "issue_code":
 			codepos = i
 		case "check_type", "issue_description":
@@ -161,7 +161,7 @@ func migrateCodes(path string) error {
 	}
 
 	if codepos == -1 {
-		log.Println("no issue code column. skipping")
+		log.Println("no check code column. skipping")
 		return nil
 	}
 

--- a/cmd/dqa/results/file.go
+++ b/cmd/dqa/results/file.go
@@ -230,6 +230,10 @@ type Result struct {
 	fileVersion uint8
 }
 
+func (r *Result) FileVersion() uint8 {
+	return r.fileVersion
+}
+
 func (r *Result) SetFileVersion(v uint8) {
 	r.fileVersion = v
 }


### PR DESCRIPTION
By default, the command assumes resolve.py is on the $PATH and
executable. Supply the `—program` option to use an explicit name
or path.

The `--resolvers` option is the path to the resolvers that the
resolver program will use.

Signed-off-by: Byron Ruth <b@devel.io>